### PR TITLE
Changes to enable Adorym model on Intel XPU device

### DIFF
--- a/adorym/array_ops.py
+++ b/adorym/array_ops.py
@@ -1,3 +1,18 @@
+import torch
+
+try:
+    try:
+        import intel_extension_for_pytorch as ipex
+    except:
+        import ipex
+except:
+    pass
+# backward compatibility
+try:
+    import torch_ipex
+except:
+    pass
+
 import numpy as np
 import os
 import h5py

--- a/adorym/differentiator.py
+++ b/adorym/differentiator.py
@@ -1,3 +1,18 @@
+import torch
+
+try:
+    try:
+        import intel_extension_for_pytorch as ipex
+    except:
+        import ipex
+except:
+    pass
+# backward compatibility
+try:
+    import torch_ipex
+except:
+    pass
+
 import numpy as np
 
 import adorym

--- a/adorym/global_settings.py
+++ b/adorym/global_settings.py
@@ -1,2 +1,5 @@
 backend = 'autograd'
 disable_sameline_output = False
+xpu = False
+run_bf16 = False
+run_fp64 = False

--- a/adorym/optimizers.py
+++ b/adorym/optimizers.py
@@ -300,6 +300,9 @@ class AdamOptimizer(Optimizer):
                 if w.get_var_device_type(x) == 'cuda':
                     m = w.to_gpu(m, w.get_var_device(x))
                     v = w.to_gpu(v, w.get_var_device(x))
+                elif w.get_var_device_type(x) == 'xpu':
+                    m = w.to_gpu(m, w.get_var_device(x))
+                    v = w.to_gpu(v, w.get_var_device(x))
                 else:
                     m = w.to_cpu(m)
                     v = w.to_cpu(v)
@@ -388,6 +391,8 @@ class MomentumOptimizer(Optimizer):
             device_0 = w.get_var_device(v)
             device_type_0 = w.get_var_device_type(v)
             if w.get_var_device_type(x) == 'cuda':
+                v = w.to_gpu(v, w.get_var_device(x))
+            elif w.get_var_device_type(x) == 'xpu':
                 v = w.to_gpu(v, w.get_var_device(x))
             else:
                 v = w.to_cpu(v)
@@ -544,6 +549,8 @@ class CurveballOptimizer(Optimizer):
         device_type_0 = w.get_var_device_type(z)
         if w.get_var_device_type(dz) == 'cuda':
             z = w.to_gpu(z, w.get_var_device(dz))
+        elif w.get_var_device_type(dz) == 'xpu':
+            z = w.to_gpu(z, w.get_var_device(dz))
         else:
             z = w.to_cpu(z)
         z = self.rho * z - self.beta * dz
@@ -601,6 +608,8 @@ class CGOptimizer(Optimizer):
         _descent_dir_old_t = self.params_whole_array_dict['descent_dir_old'][ss]
         if w.get_var_device_type(self._descent_dir_t) == 'cuda':
             _descent_dir_old_t = w.to_gpu(_descent_dir_old_t, w.get_var_device(self._descent_dir_t))
+        elif w.get_var_device_type(self._descent_dir_t) == 'xpu':
+            _descent_dir_old_t = w.to_gpu(_descent_dir_old_t, w.get_var_device(self._descent_dir_t))
         else:
             _descent_dir_old_t = w.to_cpu(_descent_dir_old_t)
 
@@ -646,6 +655,8 @@ class CGOptimizer(Optimizer):
         device_0 = w.get_var_device(_s_t)
         device_type_0 = w.get_var_device_type(_s_t)
         if w.get_var_device_type(self._descent_dir_t) == 'cuda':
+            _s_t = w.to_gpu(_s_t, w.get_var_device(self._descent_dir_t))
+        elif w.get_var_device_type(self._descent_dir_t) == 'xpu':
             _s_t = w.to_gpu(_s_t, w.get_var_device(self._descent_dir_t))
         else:
             _s_t = w.to_cpu(_s_t)

--- a/adorym/util.py
+++ b/adorym/util.py
@@ -1,3 +1,16 @@
+import torch
+try:
+    try:
+        import intel_extension_for_pytorch as ipex
+    except:
+        import ipex
+except:
+    pass
+# backward compatibility
+try:
+    import torch_ipex
+except:
+    pass
 import numpy as np
 import dxchange
 import h5py

--- a/demos/multislice_ptycho_256_theta.py
+++ b/demos/multislice_ptycho_256_theta.py
@@ -1,3 +1,16 @@
+import torch
+try:
+    try:
+        import intel_extension_for_pytorch as ipex
+    except:
+        import ipex
+except:
+    pass
+# backward compatibility
+try:
+    import torch_ipex
+except:
+    pass
 from adorym.ptychography import reconstruct_ptychography
 import numpy as np
 import dxchange
@@ -17,8 +30,12 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--epoch', default='None')
 parser.add_argument('--save_path', default='cone_256_foam_ptycho')
 parser.add_argument('--output_folder', default='test') # Will create epoch folders under this
+parser.add_argument('--xpu', default=False)
+
 args = parser.parse_args()
 epoch = args.epoch
+xpu = args.xpu
+
 if epoch == 'None':
     epoch = 0
     init = None
@@ -53,7 +70,7 @@ params_cone_marc_theta = {'fname': 'data_cone_256_foam_1nm.h5',
                         'output_folder': os.path.join(args.output_folder, 'epoch_{}'.format(epoch)),
                         'cpu_only': False,
                         'use_checkpoint': True,
-                        'save_path': 'cone_256_foam_ptycho',
+                        'save_path': args.save_path,
                         'multiscale_level': 1,
                         'n_epoch_final_pass': None,
                         'save_intermediate': False,
@@ -72,6 +89,9 @@ params_cone_marc_theta = {'fname': 'data_cone_256_foam_1nm.h5',
                         'optimizer': 'adam',
                         'backend': 'pytorch',
                         'free_prop_cm': 'inf',
+                        'xpu':xpu,
+                        'run_bfloat16': False,
+                        'run_float64': False,
                         }
 
 params = params_cone_marc_theta

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ six
 tifffile    
 pandas
 matplotlib
+git+https://github.com/data-exchange/dxchange.git
+opencv-python


### PR DESCRIPTION
Changes added:
- enable XPU device to enable functionality on Intel GPU devices with --xpu option
- support training for FP64/Fp32/BF16 precisions 
- added save_path option to run the model from a specified directory